### PR TITLE
Feature/notifications scaling

### DIFF
--- a/examples/service/notifications_consumer.py
+++ b/examples/service/notifications_consumer.py
@@ -24,7 +24,6 @@ class NotificationsConsumer:
     )
     async def updates_handler(self, channel, msg):
         logging.debug("updates_handler: got notification from channel: {} msg = '{}'".format(channel, msg))
-        raise RuntimeError('dddup')
 
     """
     Listen on channel "notification.service.notifications_producer.1_0.errors"

--- a/examples/service/notifications_producer.py
+++ b/examples/service/notifications_producer.py
@@ -39,6 +39,17 @@ class NotificationsProducer:
         logging.debug("NotifcationsProducer: Doing stuff...")
         return "Stuff done"
 
+    @rpc_method()
+    async def do_more_stuff_and_notify(self, *args):
+        logging.debug("NotifcationsProducer: Doing even more stuff...")
+        for i in range(5):
+            await asyncio.sleep(0.5)
+            msg = {'msg': "Stuff {} got updated".format(i)}
+            await self.notify.updates(msg=msg)
+
+        logging.debug("NotifcationsProducer: Even more stuff done...")
+        return "Even more stuff done"
+
 
 async def main(loop):
     await asyncio.sleep(1)
@@ -48,6 +59,7 @@ async def main(loop):
     logging.debug("main: calling remote procedure")
     try:
         print(await remote.do_stuff_and_notify())
+        print(await remote.do_more_stuff_and_notify())
     except MiteDRPCError as err:
         logging.error(err)
 

--- a/examples/service/notifications_scaled_consumer.py
+++ b/examples/service/notifications_scaled_consumer.py
@@ -1,0 +1,43 @@
+import logging
+
+from miteD.service.service import rpc_service, notification_handler
+
+"""
+When multiple replicas of a service exist each notification should be propagated to single intance only.
+To showcase that behavior run multiple instances of this script and then run the producer.
+Logs for each instance of NotificationsConsumerTypeA will be distinguished by object id: Consumer-TypeA-<id>
+"""
+
+@rpc_service(
+    name='notifications_consumer_type_A',
+    versions=['1.0'],
+    broker_urls=['nats://127.0.0.1:4222'],
+)
+class NotificationsConsumerTypeA:
+    """
+    Listen on channel "notification.service.notifications_producer.1_0.updates"
+    """
+    @notification_handler(
+        layer='service',
+        name='notifications_producer',
+        versions=['1.0'],
+        topic='updates',
+    )
+    async def updates_handler(self, channel, msg):
+        logging.debug("Consumer-TypeA-{}: updates_handler: got notification from channel: {} msg = '{}'".format(
+            id(self),
+            channel,
+            msg,
+        ))
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    service = NotificationsConsumerTypeA()
+
+    try:
+        logging.info("Starting consumer")
+        service.start()
+    except KeyboardInterrupt:
+        logging.info("Stopping consumer")
+        service.stop()

--- a/miteD/service/service.py
+++ b/miteD/service/service.py
@@ -172,7 +172,7 @@ def rpc_service(
                 coros = []
                 for h in self.notification_handlers:
                     for subject, queue in self._get_notification_subject_and_queue_pairs(h):
-                        self._logger.info("Staring notifications handler for subject/queue: {}/{}".format(
+                        self._logger.info("Starting notifications handler for subject/queue: {}/{}".format(
                             subject, queue
                         ))
                         coros.append(self._nc.subscribe(subject, queue=queue, cb=h))

--- a/miteD/service/service.py
+++ b/miteD/service/service.py
@@ -132,40 +132,50 @@ def rpc_service(
             def _get_payload(msg):
                 return loads(msg.data.decode())
 
-            async def _send_notification(self, channel, msg):
-                await self._nc.publish(channel, dumps(msg).encode())
+            async def _send_notification(self, subject, msg):
+                await self._nc.publish(subject, dumps(msg).encode())
 
             def _add_notify(self, cls):
                 if not self._notification_topics:
                     return
                 notify = Notify()
-                for topic, channel in self._assemble_producer_notification_channel_names():
-                    self._logger.info('Registering notifications channel: {}'.format(channel))
-                    setattr(notify, topic, partial(self._send_notification, channel))
+                for topic, subject in self._get_notification_topic_and_subject_pairs():
+                    self._logger.info('Registering notifications topic/subject: {}/{}'.format(topic, subject))
+                    setattr(notify, topic, partial(self._send_notification, subject))
                 cls.notify = notify
 
-            def _assemble_producer_notification_channel_names(self):
-                channels = []
-                channel_stem = 'notification.{}.{}'.format(self._layer, self._name)
+            def _get_notification_topic_and_subject_pairs(self):
+                res = []
+                subject_stem = 'notification.{}.{}'.format(self._layer, self._name)
                 for version in self._versions:
                     for topic in self._notification_topics:
-                        channels.append((topic, '{}.{}.{}'.format(channel_stem, version, topic)))
-                return channels
+                        res.append((topic, '{}.{}.{}'.format(subject_stem, version, topic)))
+                return res
 
-            def _assemble_consumer_notification_channel_names(self, handler):
-                layer = handler.__notification_layer__
-                producer_name = handler.__notification_name__
-                versions = handler.__notification_versions__
-                topic = handler.__notification_topic__
-                consumer_name = self._name
-                return ['notification.{}.{}.{}.{}.{}'.format(layer, producer_name, v, topic, consumer_name) for v in versions]
+            def _get_notification_subject_and_queue_pairs(self, handler):
+                res = []
+                for version in handler.__notification_versions__:
+                    subject = 'notification.{}.{}.{}.{}'.format(
+                        handler.__notification_layer__,
+                        handler.__notification_producer__,
+                        version,
+                        handler.__notification_topic__,
+                    )
+                    queue = '{}.{}'.format(
+                        subject,
+                        self._name
+                    )
+                    res.append((subject, queue))
+                return res
 
             async def _start_notification_handlers(self):
                 coros = []
                 for h in self.notification_handlers:
-                    channels = self._assemble_consumer_notification_channel_names(h)
-                    self._logger.info("Staring notifications handler for channels: {}".format(channels))
-                    coros.extend([self._nc.subscribe(c, cb=h) for c in channels])
+                    for subject, queue in self._get_notification_subject_and_queue_pairs(h):
+                        self._logger.info("Staring notifications handler for subject/queue: {}/{}".format(
+                            subject, queue
+                        ))
+                        coros.append(self._nc.subscribe(subject, queue=queue, cb=h))
                 await asyncio.gather(*coros)
 
         return Service
@@ -185,7 +195,7 @@ def notification_handler(layer='*', name='*', versions=None, topic='*'):
     def wrapper(fn):
         fn.__notification_handler__ = True
         fn.__notification_layer__ = layer
-        fn.__notification_name__ = name
+        fn.__notification_producer__ = name
         fn.__notification_versions__ = (format_version_str(v) for v in versions) if versions else ('*',)
         fn.__notification_topic__ = topic
 


### PR DESCRIPTION
This improvement adds support for service scaling.
It's implemented using NATS Queue-type subscription which assures 'load-balancing' - delivers message to only one of subscribers to the queue. 
Queues are created per consumer service type - so services can be scaled freely without delivery duplication issues.
The important line is 178.

Other than that it's just helper code and some naming changes (e.g use 'subject' instead of 'channel' to more closely relate to NATS naming conventions)