### PR TITLE
MiteD fixes and improvements needed for improved X1 functionality

### DIFF
--- a/miteD/middleware/types.py
+++ b/miteD/middleware/types.py
@@ -25,3 +25,7 @@ def file(fn):
     fn.__response_type__ = response.file
     return fn
 
+
+def stream(fn):
+    fn.__response_type__ = response.stream
+    return fn

--- a/miteD/utils.py
+++ b/miteD/utils.py
@@ -17,8 +17,7 @@ class CustomJsonEncoder(json.JSONEncoder):
     """
     Our custom json encoder to handle datetime tyes
     """
-    DATE_TIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
     def default(self, obj):
         if isinstance(obj, datetime.datetime):
-            return obj.strftime(self.DATE_TIME_FORMAT)
+            return obj.isoformat()
         return super(CustomJsonEncoder, self).default(obj)

--- a/miteD/utils.py
+++ b/miteD/utils.py
@@ -19,5 +19,5 @@ class CustomJsonEncoder(json.JSONEncoder):
     """
     def default(self, obj):
         if isinstance(obj, datetime.datetime):
-            return obj.isoformat()
+            return obj.astimezone().isoformat()
         return super(CustomJsonEncoder, self).default(obj)

--- a/miteD/utils.py
+++ b/miteD/utils.py
@@ -19,5 +19,5 @@ class CustomJsonEncoder(json.JSONEncoder):
     """
     def default(self, obj):
         if isinstance(obj, datetime.datetime):
-            return obj.astimezone().isoformat()
+            return obj.astimezone(datetime.timezone.utc).isoformat()
         return super(CustomJsonEncoder, self).default(obj)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='miteD',
-    version='2.1.4',
+    version='2.1.5',
     packages=find_packages(exclude=['examples']),
     description='Api and service infrastructure library for X1 (based on sanic and nats)',
     url='https://github.com/twoporeguys/miteD/',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='miteD',
-    version='2.1.3',
+    version='2.1.4',
     packages=find_packages(exclude=['examples']),
     description='Api and service infrastructure library for X1 (based on sanic and nats)',
     url='https://github.com/twoporeguys/miteD/',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='miteD',
-    version='2.1.1',
+    version='2.1.2',
     packages=find_packages(exclude=['examples']),
     description='Api and service infrastructure library for X1 (based on sanic and nats)',
     url='https://github.com/twoporeguys/miteD/',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='miteD',
-    version='2.1.2',
+    version='2.1.3',
     packages=find_packages(exclude=['examples']),
     description='Api and service infrastructure library for X1 (based on sanic and nats)',
     url='https://github.com/twoporeguys/miteD/',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='miteD',
-    version='2.1.5',
+    version='2.1.6',
     packages=find_packages(exclude=['examples']),
     description='Api and service infrastructure library for X1 (based on sanic and nats)',
     url='https://github.com/twoporeguys/miteD/',


### PR DESCRIPTION
This PR covers the following:

- Add back `@stream` response type which was lost to the annals of git
- Fix the JSON custom encoder to serialize `datetime` objects into UTC timezone based isoformat strings
- Bump the version number to `2.1.6` and tag it for the same

Note: I have tested this miteD release against my X1 branch, and my tests for all middleware apis (except SAM, will deliberate on that in person with the team) are passing